### PR TITLE
Added jenkins subdomain

### DIFF
--- a/bremen.freifunk.net.zone
+++ b/bremen.freifunk.net.zone
@@ -1,6 +1,6 @@
 $TTL 1D
 			IN	SOA	dns noc.bremen.freifunk.net. (
-				    2016092402	; Serial
+				    2016112001	; Serial
 				    4H		; Refresh
 				    1H		; Retry
 				    2W		; Expire
@@ -115,3 +115,6 @@ cloud				CNAME	ffhb-bilder.andromeda.hostedinspace.de.
 ; nebirosh
 sip				A	10.196.2.50
 smokeping			AAAA	2a02:2919:1000:0:ba27:ebff:fe69:2879
+
+; jantede
+jenkins				A	5.230.134.254


### PR DESCRIPTION
I have added the subdomain jenkins pointing to the jenkins server which is building our firmware. Think it would be neat to make that service available using ffhb.de or bremen.freifunk.net subdomain.

(Sorry for the duplicate, I forgot to update the serial)